### PR TITLE
Ignore *.sb3 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Project exclude paths
 /venv/
+*.sb3


### PR DESCRIPTION
This is so that, if the user has an SB3 file in the directory, and has a for or someone with write access puts an SB3 file in the directory and commits. The file will not be added to the source